### PR TITLE
Add Flask skeleton for planner web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Python
+__pycache__/
+*.pyc
+
+# Environment
+.env
+
+# SQLite database
+app.db
+
+# IDE
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # PlanerwebseiteIT
+
+Dies ist ein einfaches Grundgerüst für eine persönliche Planer-Webseite. Die Anwendung basiert auf [Flask](https://palletsprojects.com/p/flask/) und verwendet SQLite als lokale Datenbank. Sie bietet Platzhalter für ein Ticketsystem, einen Kalender und ein kleines Inventar.
+
+## Installation
+
+1. Python 3 installieren.
+2. Abhängigkeiten mit `pip install -r requirements.txt` installieren.
+3. Optional: die Umgebungsvariablen `PLANNER_SECRET_KEY` und `PLANNER_ADMIN_PASSWORD` setzen.
+
+## Starten der Anwendung
+
+```
+python app.py
+```
+
+Beim ersten Start wird automatisch ein Benutzer `admin` angelegt. Nach dem Login können die vorbereiteten Seiten für Tickets, Kalender und Inventar aufgerufen werden.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,107 @@
+from flask import Flask, render_template, redirect, request, session, url_for
+from flask_sqlalchemy import SQLAlchemy
+from werkzeug.security import generate_password_hash, check_password_hash
+import os
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = os.environ.get('PLANNER_SECRET_KEY', 'change-me')
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///app.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db = SQLAlchemy(app)
+
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(200), nullable=False)
+
+
+class Ticket(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200))
+    description = db.Column(db.Text)
+    status = db.Column(db.String(50), default='open')
+
+
+class Event(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200))
+    date = db.Column(db.String(50))
+    description = db.Column(db.Text)
+
+
+class Item(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(200))
+    quantity = db.Column(db.Integer)
+    description = db.Column(db.Text)
+
+
+@app.before_first_request
+def create_tables():
+    db.create_all()
+    if not User.query.filter_by(username='admin').first():
+        password = os.environ.get('PLANNER_ADMIN_PASSWORD', 'admin')
+        hashed = generate_password_hash(password)
+        user = User(username='admin', password_hash=hashed)
+        db.session.add(user)
+        db.session.commit()
+
+
+def logged_in() -> bool:
+    return 'user_id' in session
+
+
+@app.route('/')
+def index():
+    if not logged_in():
+        return redirect(url_for('login'))
+    return render_template('index.html')
+
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        user = User.query.filter_by(username=username).first()
+        if user and check_password_hash(user.password_hash, password):
+            session['user_id'] = user.id
+            return redirect(url_for('index'))
+        return render_template('login.html', error='Ungültige Zugangsdaten')
+    return render_template('login.html')
+
+
+@app.route('/logout')
+def logout():
+    session.clear()
+    return redirect(url_for('login'))
+
+
+@app.route('/tickets')
+def tickets():
+    if not logged_in():
+        return redirect(url_for('login'))
+    tickets = Ticket.query.all()
+    return render_template('tickets.html', tickets=tickets)
+
+
+@app.route('/calendar')
+def calendar_view():
+    if not logged_in():
+        return redirect(url_for('login'))
+    events = Event.query.all()
+    return render_template('calendar.html', events=events)
+
+
+@app.route('/inventory')
+def inventory():
+    if not logged_in():
+        return redirect(url_for('login'))
+    items = Item.query.all()
+    return render_template('inventory.html', items=items)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask==2.3.2
+Flask-SQLAlchemy==3.1.1
+Werkzeug==3.0.1

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>{% block title %}Planer{% endblock %}</title>
+</head>
+<body>
+<nav>
+    <a href="{{ url_for('index') }}">Home</a> |
+    <a href="{{ url_for('tickets') }}">Tickets</a> |
+    <a href="{{ url_for('calendar_view') }}">Kalender</a> |
+    <a href="{{ url_for('inventory') }}">Inventar</a> |
+    <a href="{{ url_for('logout') }}">Logout</a>
+</nav>
+<hr>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}Kalender{% endblock %}
+{% block content %}
+<h1>Kalender</h1>
+<ul>
+{% for event in events %}
+    <li>{{ event.date }} - {{ event.title }}</li>
+{% else %}
+    <li>Keine Termine vorhanden.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Übersicht{% endblock %}
+{% block content %}
+<h1>Willkommen zum Planer</h1>
+<p>Wähle oben eine Funktion aus.</p>
+{% endblock %}

--- a/templates/inventory.html
+++ b/templates/inventory.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}Inventar{% endblock %}
+{% block content %}
+<h1>Artikel-Inventar</h1>
+<ul>
+{% for item in items %}
+    <li>{{ item.name }}: {{ item.quantity }}</li>
+{% else %}
+    <li>Keine Artikel vorhanden.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<h1>Login</h1>
+{% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+<form method="post">
+    <label>Benutzername: <input type="text" name="username"></label><br>
+    <label>Passwort: <input type="password" name="password"></label><br>
+    <button type="submit">Login</button>
+</form>
+{% endblock %}

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}Tickets{% endblock %}
+{% block content %}
+<h1>Tickets</h1>
+<ul>
+{% for ticket in tickets %}
+    <li>{{ ticket.title }} ({{ ticket.status }})</li>
+{% else %}
+    <li>Keine Tickets vorhanden.</li>
+{% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- initialize Flask project with SQLite database
- add minimal login and placeholder pages for tickets, calendar and inventory
- include HTML templates
- update README with setup instructions
- add .gitignore and requirements list

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d5058badc83238d067811ebe73fe1