### PR TITLE
Add configurable DB URI and auth tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Python
+__pycache__/
+*.pyc
+
+# Environment
+.env
+
+# SQLite database
+app.db
+
+# IDE
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # PlanerwebseiteIT
+
+Dies ist ein einfaches Grundgerüst für eine persönliche Planer-Webseite. Die Anwendung basiert auf [Flask](https://palletsprojects.com/p/flask/) und verwendet SQLite als lokale Datenbank. Sie bietet Platzhalter für ein Ticketsystem, einen Kalender und ein kleines Inventar.
+
+## Installation
+
+1. Python 3 installieren.
+2. Abhängigkeiten mit `pip install -r requirements.txt` installieren.
+3. Optional: die Umgebungsvariablen `PLANNER_SECRET_KEY` und `PLANNER_ADMIN_PASSWORD` setzen.
+4. Optional: `PLANNER_DATABASE_URI` festlegen, um einen anderen Datenbankpfad zu verwenden.
+
+## Starten der Anwendung
+
+```
+python app.py
+```
+
+Beim ersten Start wird automatisch ein Benutzer `admin` angelegt. Weitere Nutzer können über die Registrierungsseite erstellt werden. Nach dem Login können die vorbereiteten Seiten für Tickets, Kalender und Inventar aufgerufen werden.
+
+## Tests
+Führe `pytest -q` aus, um die Authentifizierung zu testen.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,133 @@
+from functools import wraps
+from flask import Flask, render_template, redirect, request, session, url_for, g
+from flask_sqlalchemy import SQLAlchemy
+from werkzeug.security import generate_password_hash, check_password_hash
+import os
+
+app = Flask(__name__)
+app.config["SECRET_KEY"] = os.environ.get("PLANNER_SECRET_KEY", "change-me")
+app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get("PLANNER_DATABASE_URI", "sqlite:///app.db")
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+db = SQLAlchemy(app)
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(200), nullable=False)
+
+
+class Ticket(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200))
+    description = db.Column(db.Text)
+    status = db.Column(db.String(50), default='open')
+
+
+class Event(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200))
+    date = db.Column(db.String(50))
+    description = db.Column(db.Text)
+
+
+class Item(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(200))
+    quantity = db.Column(db.Integer)
+    description = db.Column(db.Text)
+
+
+@app.before_first_request
+def create_tables():
+    db.create_all()
+    if not User.query.filter_by(username='admin').first():
+        password = os.environ.get('PLANNER_ADMIN_PASSWORD', 'admin')
+        hashed = generate_password_hash(password)
+        user = User(username='admin', password_hash=hashed)
+        db.session.add(user)
+        db.session.commit()
+
+
+@app.before_request
+def load_user():
+    g.user = None
+    if logged_in():
+        g.user = User.query.get(session['user_id'])
+
+
+def logged_in() -> bool:
+    return 'user_id' in session
+
+
+def login_required(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if not logged_in():
+            return redirect(url_for('login'))
+        return func(*args, **kwargs)
+    return wrapper
+
+
+@app.route('/')
+@login_required
+def index():
+    return render_template('index.html')
+
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        user = User.query.filter_by(username=username).first()
+        if user and check_password_hash(user.password_hash, password):
+            session['user_id'] = user.id
+            return redirect(url_for('index'))
+        return render_template('login.html', error='Ungültige Zugangsdaten')
+    return render_template('login.html')
+
+
+@app.route('/register', methods=['GET', 'POST'])
+def register():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        if User.query.filter_by(username=username).first():
+            return render_template('register.html', error='Benutzer existiert bereits')
+        hashed = generate_password_hash(password)
+        user = User(username=username, password_hash=hashed)
+        db.session.add(user)
+        db.session.commit()
+        session['user_id'] = user.id
+        return redirect(url_for('index'))
+    return render_template('register.html')
+
+
+@app.route('/logout')
+def logout():
+    session.clear()
+    return redirect(url_for('login'))
+
+
+@app.route('/tickets')
+@login_required
+def tickets():
+    tickets = Ticket.query.all()
+    return render_template('tickets.html', tickets=tickets)
+
+
+@app.route('/calendar')
+@login_required
+def calendar_view():
+    events = Event.query.all()
+    return render_template('calendar.html', events=events)
+
+
+@app.route('/inventory')
+@login_required
+def inventory():
+    items = Item.query.all()
+    return render_template('inventory.html', items=items)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask==2.3.2
+Flask-SQLAlchemy==3.1.1
+Werkzeug==3.0.1
+pytest==8.2.0

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>{% block title %}Planer{% endblock %}</title>
+</head>
+<body>
+<nav>
+    <a href="{{ url_for('index') }}">Home</a> |
+    <a href="{{ url_for('tickets') }}">Tickets</a> |
+    <a href="{{ url_for('calendar_view') }}">Kalender</a> |
+    <a href="{{ url_for('inventory') }}">Inventar</a> |
+    {% if session.get('user_id') %}
+    <a href="{{ url_for('logout') }}">Logout</a>
+    {% else %}
+    <a href="{{ url_for('login') }}">Login</a> |
+    <a href="{{ url_for('register') }}">Registrieren</a>
+    {% endif %}
+</nav>
+<hr>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}Kalender{% endblock %}
+{% block content %}
+<h1>Kalender</h1>
+<ul>
+{% for event in events %}
+    <li>{{ event.date }} - {{ event.title }}</li>
+{% else %}
+    <li>Keine Termine vorhanden.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block title %}Übersicht{% endblock %}
+{% block content %}
+<h1>Willkommen zum Planer</h1>
+<p>Du bist angemeldet als {{ g.user.username }}.</p>
+<p>Wähle oben eine Funktion aus.</p>
+{% endblock %}

--- a/templates/inventory.html
+++ b/templates/inventory.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}Inventar{% endblock %}
+{% block content %}
+<h1>Artikel-Inventar</h1>
+<ul>
+{% for item in items %}
+    <li>{{ item.name }}: {{ item.quantity }}</li>
+{% else %}
+    <li>Keine Artikel vorhanden.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<h1>Login</h1>
+{% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+<form method="post">
+    <label>Benutzername: <input type="text" name="username"></label><br>
+    <label>Passwort: <input type="password" name="password"></label><br>
+    <button type="submit">Login</button>
+</form>
+<p>Noch keinen Account? <a href="{{ url_for('register') }}">Registrieren</a></p>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block title %}Registrieren{% endblock %}
+{% block content %}
+<h1>Registrieren</h1>
+{% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+<form method="post">
+    <label>Benutzername: <input type="text" name="username"></label><br>
+    <label>Passwort: <input type="password" name="password"></label><br>
+    <button type="submit">Registrieren</button>
+</form>
+{% endblock %}

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}Tickets{% endblock %}
+{% block content %}
+<h1>Tickets</h1>
+<ul>
+{% for ticket in tickets %}
+    <li>{{ ticket.title }} ({{ ticket.status }})</li>
+{% else %}
+    <li>Keine Tickets vorhanden.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,56 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+# Use in-memory SQLite DB for tests before importing app
+os.environ['PLANNER_DATABASE_URI'] = 'sqlite:///:memory:'
+
+import app as planner
+from flask import g
+
+
+def setup_client():
+    """Create a test client with initialized database."""
+    with planner.app.app_context():
+        planner.create_tables()
+    return planner.app.test_client()
+
+
+def test_register_login_logout():
+    client = setup_client()
+
+    # Registration logs in the user automatically
+    resp = client.post('/register', data={
+        'username': 'alice',
+        'password': 'secret'
+    }, follow_redirects=True)
+    assert 'Willkommen zum Planer' in resp.get_data(as_text=True)
+
+    # Logout and ensure protected route redirects
+    client.get('/logout')
+    resp = client.get('/tickets')
+    assert resp.status_code == 302
+    assert '/login' in resp.headers['Location']
+
+    # Log in again
+    resp = client.post('/login', data={
+        'username': 'alice',
+        'password': 'secret'
+    }, follow_redirects=True)
+    assert 'Willkommen zum Planer' in resp.get_data(as_text=True)
+
+    # Authenticated access to protected route
+    resp = client.get('/tickets')
+    assert resp.status_code == 200
+
+
+def test_invalid_login():
+    client = setup_client()
+
+    resp = client.post('/login', data={
+        'username': 'admin',
+        'password': 'wrong'
+    }, follow_redirects=True)
+    assert 'Ungültige Zugangsdaten' in resp.get_data(as_text=True)
+
+


### PR DESCRIPTION
## Summary
- allow overriding `SQLALCHEMY_DATABASE_URI` via environment variable
- document new variable and how to run tests in README
- include pytest in requirements
- add basic tests for registration and login

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685d5058badc83238d067811ebe73fe1